### PR TITLE
initialise and populate pacman keyring on steamos/steam deck

### DIFF
--- a/docs/source/linuxaemulussetup.rst
+++ b/docs/source/linuxaemulussetup.rst
@@ -15,8 +15,7 @@ Steam Deck
     sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
     sudo pacman -Sy
     sudo pacman-key --init    
-    sudo pacman-key --populate holo
-    sudo pacman-key --populate archlinux
+    sudo pacman-key --populate holo archlinux
     sudo pacman -S curl wine winetricks p7zip unzip desktop-file-utils lib32-gnutls lib32-gst-plugins-base git
     sudo steamos-readonly enable
 

--- a/docs/source/linuxaemulussetup.rst
+++ b/docs/source/linuxaemulussetup.rst
@@ -50,12 +50,8 @@ Install
 
     |image160|
 
-3.  Once running you will get a prompt to install wine mono. Click install on it to stop it from prompting again. The install script will automatically remove it from this prefix later.
+3.  Once the script has finished running, Aemulus can be opened by navigating to `Games > Aemulus Package Manager` in your launcher. An example of how this looks in KDE is provided. 
     |image161|
 
-4.  Once the script has finished running, Aemulus can be opened by navigating to `Games > Aemulus Package Manager` in your launcher. An example of how this looks in KDE is provided. 
-    |image162|
-
 .. |image160| image:: https://imgur.com/Po17FKf.png
-.. |image161| image:: https://imgur.com/TgZaoBg.png
-.. |image162| image:: https://imgur.com/2V5l7Eh.png
+.. |image161| image:: https://imgur.com/2V5l7Eh.png

--- a/docs/source/linuxaemulussetup.rst
+++ b/docs/source/linuxaemulussetup.rst
@@ -14,6 +14,9 @@ Steam Deck
     sudo steamos-readonly disable
     sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
     sudo pacman -Sy
+    sudo pacman-key --init    
+    sudo pacman-key --populate holo
+    sudo pacman-key --populate archlinux
     sudo pacman -S curl wine winetricks p7zip unzip desktop-file-utils lib32-gnutls lib32-gst-plugins-base git
     sudo steamos-readonly enable
 

--- a/docs/source/linuxaemulussetup.rst
+++ b/docs/source/linuxaemulussetup.rst
@@ -13,6 +13,7 @@ Steam Deck
 
     sudo steamos-readonly disable
     sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+    sudo pacman -Sy
     sudo pacman -S curl wine winetricks p7zip unzip desktop-file-utils lib32-gnutls lib32-gst-plugins-base git
     sudo steamos-readonly enable
 
@@ -21,6 +22,7 @@ Arch Linux
 .. code-block:: sh
 
     sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+    sudo pacman -Sy
     sudo pacman -S curl wine winetricks p7zip unzip desktop-file-utils lib32-gnutls lib32-gst-plugins-base git
 
 Debian/Ubuntu


### PR DESCRIPTION
needed to be able to install required packages for aemulus to run, without it you get a bunch of corrupted package errors bc it cant check the pgp signatures or whatever

idk why github is saying i changed lines after line 19 but i assume its bc of the formatting since i added extra lines for those commands